### PR TITLE
[AI] RAG 임베딩 과정 추가 및 아키텍처 재정비

### DIFF
--- a/rag/src/application/ingestion_service.py
+++ b/rag/src/application/ingestion_service.py
@@ -1,7 +1,8 @@
 import logging
+from pathlib import Path
 
 from infrastructure.ingestion.chunk import chunk_text
-from infrastructure.ingestion.docs_loader import iter_pdfs_from_dir
+from infrastructure.ingestion.docs_loader import DocumentPayload, iter_pdfs_from_dir
 from infrastructure.ingestion.embed import embed_text
 from infrastructure.ingestion.index import index_embeddings
 
@@ -26,3 +27,10 @@ class IngestionService:
             self.ingest(payload.doc_id, payload.text, payload.metadata)
         if not saw_any:
             logger.warning("No PDF files found under data dir: %s", data_dir)
+
+    def extract_raw_texts(self, data_dir: str | None = None) -> list[DocumentPayload]:
+        resolved_dir = data_dir or str(Path(__file__).resolve().parents[1] / "data")
+        payloads = list(iter_pdfs_from_dir(resolved_dir))
+        if not payloads:
+            logger.warning("No PDF files found under data dir: %s", resolved_dir)
+        return payloads

--- a/rag/src/application/ingestion_service.py
+++ b/rag/src/application/ingestion_service.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 
 from infrastructure.ingestion.chunk import chunk_text
-from infrastructure.ingestion.docs_loader import DocumentPayload, iter_pdfs_from_dir
+from infrastructure.ingestion.docs_loader import DocumentPayload, iter_pdfs_from_dir, load_pdf
 from infrastructure.ingestion.embed import embed_text
 from infrastructure.ingestion.index import index_embeddings
 
@@ -34,3 +34,10 @@ class IngestionService:
         if not payloads:
             logger.warning("No PDF files found under data dir: %s", resolved_dir)
         return payloads
+
+    def ingest_pdf_file(self, file_path: Path, base_dir: Path) -> None:
+        payload = load_pdf(file_path, base_dir)
+        if not payload.text:
+            logger.warning("Empty PDF text extracted: %s", file_path)
+            return
+        self.ingest(payload.doc_id, payload.text, payload.metadata)

--- a/rag/src/application/risk_report_parser.py
+++ b/rag/src/application/risk_report_parser.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+class RiskReportParser:
+    # LLM 출력(JSON 문자열)을 파싱하는 전용 파서
+    def parse(self, raw: str) -> Dict[str, Any]:
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            try:
+                return json.loads(raw[start : end + 1])
+            except json.JSONDecodeError:
+                logger.warning("Failed to parse JSON from LLM output.")
+        return {}

--- a/rag/src/application/risk_report_prompt_builder.py
+++ b/rag/src/application/risk_report_prompt_builder.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+from application.risk_report_retriever import RiskReportContext
+
+
+class RiskReportPromptBuilder:
+    # 리스크 리포트 프롬프트 및 근거(citations) 생성 전담
+    def build_prompt(self, context: RiskReportContext, citations: List[Dict[str, str]]) -> str:
+        return (
+            "너는 IT 프로젝트 리스크 관리 전문가다. 아래 문서들을 근거로 "
+            "일정 지연 리스크를 PI 매트릭스(발생 가능성/영향도 1~5)로 평가하라.\n"
+            "사내 리스크 데이터가 충분하지 않아 몬테카를로 대신 정성적 PI 매트릭스를 사용한다.\n"
+            "문서 기반 정성 분석은 LLM이 잘하기 때문에 RAG로 근거를 요약한다.\n\n"
+            "응답은 JSON만 출력하고, 다음 키를 포함하라:\n"
+            '{"likelihood": 1, "impact": 1, "summary": "...", "rationale": "..."}\n\n'
+            f"[프로젝트 메타]\n{json.dumps(context.project, ensure_ascii=False, default=str)}\n\n"
+            f"[주간 보고]\n{json.dumps(context.weekly_reports, ensure_ascii=False, default=str)}\n\n"
+            f"[회의록]\n{json.dumps(context.meeting_records, ensure_ascii=False, default=str)}\n\n"
+            f"[일정 변경 로그]\n{json.dumps(context.events_logs, ensure_ascii=False, default=str)}\n\n"
+            f"[태스크 변경 로그]\n{json.dumps(context.task_update_logs, ensure_ascii=False, default=str)}\n\n"
+            f"[마일스톤 변경 로그]\n{json.dumps(context.milestone_update_logs, ensure_ascii=False, default=str)}\n\n"
+            f"[프로젝트 문서]\n{json.dumps(context.project_documents, ensure_ascii=False, default=str)}\n\n"
+            f"[벡터 검색 결과]\n{json.dumps(context.vector_evidence, ensure_ascii=False, default=str)}\n\n"
+            f"[참고 문서 목록]\n{json.dumps(citations, ensure_ascii=False, default=str)}\n"
+        )
+
+    def build_citations(self, context: RiskReportContext) -> List[Dict[str, str]]:
+        citations: List[Dict[str, str]] = []
+        for item in context.weekly_reports:
+            citations.append(self._citation("weekly_report", item.get("report_id"), item.get("summary_text")))
+        for item in context.meeting_records:
+            citations.append(self._citation("meeting_record", item.get("meeting_id"), item.get("agenda_summary")))
+        for item in context.events_logs:
+            citations.append(self._citation("events_log", item.get("event_log_id"), item.get("log_description")))
+        for item in context.task_update_logs:
+            citations.append(self._citation("task_update_log", item.get("task_update_log_id"), item.get("update_reason")))
+        for item in context.milestone_update_logs:
+            citations.append(
+                self._citation("milestone_update_log", item.get("milestone_update_log_id"), item.get("update_reason"))
+            )
+        for item in context.project_documents:
+            citations.append(self._citation("project_document", item.get("doc_id"), item.get("extracted_text")))
+        for item in context.vector_evidence:
+            citations.append(self._citation("vector_evidence", item.get("doc_id"), item.get("text")))
+        return [item for item in citations if item["excerpt"]]
+
+    def _citation(self, source_type: str, source_id: Any, text: Any) -> Dict[str, str]:
+        excerpt = str(text or "").strip().replace("\n", " ")
+        if len(excerpt) > 240:
+            excerpt = excerpt[:240] + "..."
+        return {
+            "source_type": source_type,
+            "source_id": str(source_id) if source_id is not None else "",
+            "excerpt": excerpt,
+        }

--- a/rag/src/application/risk_report_retriever.py
+++ b/rag/src/application/risk_report_retriever.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time
+from typing import Any, Dict, List
+
+from config import settings
+from domain.models import SearchResult
+from infrastructure.mariadb_repo import MariaDBRepository
+from infrastructure.qdrant_store import QdrantAdapter
+
+
+@dataclass(frozen=True)
+class RiskReportContext:
+    project: Dict[str, Any]
+    weekly_reports: List[Dict[str, Any]]
+    meeting_records: List[Dict[str, Any]]
+    events_logs: List[Dict[str, Any]]
+    task_update_logs: List[Dict[str, Any]]
+    milestone_update_logs: List[Dict[str, Any]]
+    project_documents: List[Dict[str, Any]]
+    vector_evidence: List[Dict[str, Any]]
+
+
+class RiskReportRetriever:
+    # 리스크 리포트에 필요한 데이터를 MariaDB/Qdrant에서 수집하는 리트리버
+    def __init__(self) -> None:
+        self._repo = MariaDBRepository()
+        self._vector = QdrantAdapter()
+
+    def fetch(self, *, project_id: str, week_start: date, week_end: date) -> RiskReportContext:
+        start_dt = datetime.combine(week_start, time.min)
+        end_dt = datetime.combine(week_end, time.max)
+        project = self._repo.fetch_project(project_id)
+        weekly_reports = self._repo.fetch_weekly_reports(project_id, week_start, week_end)
+        meeting_records = self._repo.fetch_meeting_records(project_id, start_dt, end_dt)
+        events_logs = self._repo.fetch_events_logs(project_id, start_dt, end_dt)
+        task_update_logs = self._repo.fetch_task_update_logs(project_id, start_dt, end_dt)
+        milestone_update_logs = self._repo.fetch_milestone_update_logs(project_id, start_dt, end_dt)
+        project_documents = self._repo.fetch_project_documents(project_id)
+        vector_hits = self._fetch_vector_evidence(project_id, week_start, week_end)
+        return RiskReportContext(
+            project=project,
+            weekly_reports=weekly_reports,
+            meeting_records=meeting_records,
+            events_logs=events_logs,
+            task_update_logs=task_update_logs,
+            milestone_update_logs=milestone_update_logs,
+            project_documents=project_documents,
+            vector_evidence=vector_hits,
+        )
+
+    def _fetch_vector_evidence(self, project_id: str, week_start: date, week_end: date) -> List[Dict[str, Any]]:
+        query = f"프로젝트 {project_id} 일정 지연 리스크 분석 ({week_start}~{week_end})"
+        results = self._vector.search(query, k=settings.top_k)
+        return [self._to_evidence(item) for item in results]
+
+    def _to_evidence(self, item: SearchResult) -> Dict[str, Any]:
+        return {
+            "doc_id": item.doc_id,
+            "score": item.score,
+            "text": item.text,
+            "metadata": item.metadata,
+        }

--- a/rag/src/application/risk_report_service.py
+++ b/rag/src/application/risk_report_service.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-import json
 import logging
 import time as time_module
-from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
+from typing import Any, Dict
 from zoneinfo import ZoneInfo
-from typing import Any, Dict, List
 
+from application.risk_report_parser import RiskReportParser
+from application.risk_report_prompt_builder import RiskReportPromptBuilder
+from application.risk_report_retriever import RiskReportContext, RiskReportRetriever
 from config import settings
 from domain.models import RiskAnalysisResult
 from infrastructure.llm_client import LLMClient
@@ -16,21 +17,14 @@ from infrastructure.mariadb_repo import MariaDBRepository
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class RiskReportContext:
-    project: Dict[str, Any]
-    weekly_reports: List[Dict[str, Any]]
-    meeting_records: List[Dict[str, Any]]
-    events_logs: List[Dict[str, Any]]
-    task_update_logs: List[Dict[str, Any]]
-    milestone_update_logs: List[Dict[str, Any]]
-    project_documents: List[Dict[str, Any]]
-
-
 class RiskReportService:
+    # 리스크 리포트 생성 유스케이스를 오케스트레이션(수집/프롬프트/파싱/저장)하는 서비스
     def __init__(self) -> None:
-        self._repo = MariaDBRepository()
+        self._retriever = RiskReportRetriever()
+        self._prompt_builder = RiskReportPromptBuilder()
+        self._parser = RiskReportParser()
         self._llm = LLMClient()
+        self._repo = MariaDBRepository()
 
     def generate(self, *, project_id: str, week_start: date, week_end: date) -> RiskAnalysisResult:
         def log_step(label: str, start: float) -> float:
@@ -39,47 +33,20 @@ class RiskReportService:
             return time_module.perf_counter()
 
         t0 = time_module.perf_counter()
-        start_dt = datetime.combine(week_start, time.min)
-        end_dt = datetime.combine(week_end, time.max)
         t0 = log_step("range_build", t0)
+        context = self._retriever.fetch(project_id=project_id, week_start=week_start, week_end=week_end)
+        t0 = log_step("fetch_context", t0)
         if settings.environment.lower() == "test":
-            end_dt = min(end_dt, datetime.now())
-            start_dt = max(start_dt, end_dt - timedelta(days=2))
-            t0 = log_step("test_window_adjust", t0)
-        project = self._repo.fetch_project(project_id)
-        t0 = log_step("fetch_project", t0)
-        weekly_reports = self._repo.fetch_weekly_reports(project_id, week_start, week_end)
-        t0 = log_step("fetch_weekly_reports", t0)
-        meeting_records = self._repo.fetch_meeting_records(project_id, start_dt, end_dt)
-        t0 = log_step("fetch_meeting_records", t0)
-        events_logs = self._repo.fetch_events_logs(project_id, start_dt, end_dt)
-        t0 = log_step("fetch_events_logs", t0)
-        task_update_logs = self._repo.fetch_task_update_logs(project_id, start_dt, end_dt)
-        t0 = log_step("fetch_task_update_logs", t0)
-        milestone_update_logs = self._repo.fetch_milestone_update_logs(project_id, start_dt, end_dt)
-        t0 = log_step("fetch_milestone_update_logs", t0)
-        project_documents = self._repo.fetch_project_documents(project_id)
-        t0 = log_step("fetch_project_documents", t0)
-        context = RiskReportContext(
-            project=project,
-            weekly_reports=weekly_reports,
-            meeting_records=meeting_records,
-            events_logs=events_logs,
-            task_update_logs=task_update_logs,
-            milestone_update_logs=milestone_update_logs,
-            project_documents=project_documents,
-        )
-        if settings.environment.lower() == "test":
-            context = self._apply_test_limits(context)
+            context = self._apply_test_limits(context, week_start=week_start, week_end=week_end)
             t0 = log_step("apply_test_limits", t0)
-        citations = self._build_citations(context)
+        citations = self._prompt_builder.build_citations(context)
         t0 = log_step("build_citations", t0)
-        prompt = self._build_prompt(context, citations)
+        prompt = self._prompt_builder.build_prompt(context, citations)
         logger.info("RiskReport prompt_preview=%s", prompt[:1000])
         t0 = log_step("build_prompt", t0)
         raw = self._llm.generate(prompt)
         t0 = log_step("llm_generate", t0)
-        parsed = self._parse_json(raw)
+        parsed = self._parser.parse(raw)
         t0 = log_step("parse_json", t0)
 
         likelihood = self._clamp_score(parsed.get("likelihood", 3))
@@ -101,13 +68,31 @@ class RiskReportService:
         log_step("save_risk_analysis", t0)
         return result
 
-    def _apply_test_limits(self, context: RiskReportContext) -> RiskReportContext:
+    def _apply_test_limits(
+        self, context: RiskReportContext, *, week_start: date, week_end: date
+    ) -> RiskReportContext:
         max_docs = 5
         max_chars = 800
+        start_dt = datetime.combine(week_start, time.min)
+        end_dt = datetime.combine(week_end, time.max)
+        end_dt = min(end_dt, datetime.now())
+        start_dt = max(start_dt, end_dt - timedelta(days=2))
+
+        weekly_reports = [
+            self._trim_weekly_report(item, max_chars)
+            for item in context.weekly_reports
+            if self._within_date(item.get("week_start_date"), start_dt.date(), end_dt.date())
+        ][:max_docs]
+        meeting_records = [
+            self._trim_meeting_record(item, max_chars)
+            for item in context.meeting_records
+            if self._within_datetime(item.get("meeting_date"), start_dt, end_dt)
+        ][:max_docs]
+
         return RiskReportContext(
             project=context.project,
-            weekly_reports=[self._trim_weekly_report(item, max_chars) for item in context.weekly_reports[:max_docs]],
-            meeting_records=[self._trim_meeting_record(item, max_chars) for item in context.meeting_records[:max_docs]],
+            weekly_reports=weekly_reports,
+            meeting_records=meeting_records,
             events_logs=[self._trim_text_field(item, "log_description", max_chars) for item in context.events_logs[:max_docs]],
             task_update_logs=[self._trim_text_field(item, "update_reason", max_chars) for item in context.task_update_logs[:max_docs]],
             milestone_update_logs=[
@@ -117,7 +102,18 @@ class RiskReportService:
             project_documents=[
                 self._trim_text_field(item, "extracted_text", max_chars) for item in context.project_documents[:max_docs]
             ],
+            vector_evidence=[self._trim_text_field(item, "text", max_chars) for item in context.vector_evidence[:max_docs]],
         )
+
+    def _within_date(self, value: Any, start: date, end: date) -> bool:
+        if not isinstance(value, date):
+            return True
+        return start <= value <= end
+
+    def _within_datetime(self, value: Any, start: datetime, end: datetime) -> bool:
+        if not isinstance(value, datetime):
+            return True
+        return start <= value <= end
 
     def _trim_weekly_report(self, item: Dict[str, Any], max_chars: int) -> Dict[str, Any]:
         trimmed = dict(item)
@@ -140,66 +136,6 @@ class RiskReportService:
         if len(text) > max_chars:
             return text[:max_chars] + "..."
         return text
-
-    def _build_prompt(self, context: RiskReportContext, citations: List[Dict[str, str]]) -> str:
-        return (
-            "너는 IT 프로젝트 리스크 관리 전문가다. 아래 문서들을 근거로 "
-            "일정 지연 리스크를 PI 매트릭스(발생 가능성/영향도 1~5)로 평가하라.\n"
-            "사내 리스크 데이터가 충분하지 않아 몬테카를로 대신 정성적 PI 매트릭스를 사용한다.\n"
-            "문서 기반 정성 분석은 LLM이 잘하기 때문에 RAG로 근거를 요약한다.\n\n"
-            "응답은 JSON만 출력하고, 다음 키를 포함하라:\n"
-            '{"likelihood": 1, "impact": 1, "summary": "...", "rationale": "..."}\n\n'
-            f"[프로젝트 메타]\n{json.dumps(context.project, ensure_ascii=False, default=str)}\n\n"
-            f"[주간 보고]\n{json.dumps(context.weekly_reports, ensure_ascii=False, default=str)}\n\n"
-            f"[회의록]\n{json.dumps(context.meeting_records, ensure_ascii=False, default=str)}\n\n"
-            f"[일정 변경 로그]\n{json.dumps(context.events_logs, ensure_ascii=False, default=str)}\n\n"
-            f"[태스크 변경 로그]\n{json.dumps(context.task_update_logs, ensure_ascii=False, default=str)}\n\n"
-            f"[마일스톤 변경 로그]\n{json.dumps(context.milestone_update_logs, ensure_ascii=False, default=str)}\n\n"
-            f"[프로젝트 문서]\n{json.dumps(context.project_documents, ensure_ascii=False, default=str)}\n\n"
-            f"[참고 문서 목록]\n{json.dumps(citations, ensure_ascii=False, default=str)}\n"
-        )
-
-    def _build_citations(self, context: RiskReportContext) -> List[Dict[str, str]]:
-        citations: List[Dict[str, str]] = []
-        for item in context.weekly_reports:
-            citations.append(self._citation("weekly_report", item.get("report_id"), item.get("summary_text")))
-        for item in context.meeting_records:
-            citations.append(self._citation("meeting_record", item.get("meeting_id"), item.get("agenda_summary")))
-        for item in context.events_logs:
-            citations.append(self._citation("events_log", item.get("event_log_id"), item.get("log_description")))
-        for item in context.task_update_logs:
-            citations.append(self._citation("task_update_log", item.get("task_update_log_id"), item.get("update_reason")))
-        for item in context.milestone_update_logs:
-            citations.append(
-                self._citation("milestone_update_log", item.get("milestone_update_log_id"), item.get("update_reason"))
-            )
-        for item in context.project_documents:
-            citations.append(self._citation("project_document", item.get("doc_id"), item.get("extracted_text")))
-        return [item for item in citations if item["excerpt"]]
-
-    def _citation(self, source_type: str, source_id: Any, text: Any) -> Dict[str, str]:
-        excerpt = str(text or "").strip().replace("\n", " ")
-        if len(excerpt) > 240:
-            excerpt = excerpt[:240] + "..."
-        return {
-            "source_type": source_type,
-            "source_id": str(source_id) if source_id is not None else "",
-            "excerpt": excerpt,
-        }
-
-    def _parse_json(self, raw: str) -> Dict[str, Any]:
-        try:
-            return json.loads(raw)
-        except json.JSONDecodeError:
-            pass
-        start = raw.find("{")
-        end = raw.rfind("}")
-        if start != -1 and end != -1 and end > start:
-            try:
-                return json.loads(raw[start : end + 1])
-            except json.JSONDecodeError:
-                logger.warning("Failed to parse JSON from LLM output.")
-        return {}
 
     def _clamp_score(self, value: Any) -> int:
         try:

--- a/rag/src/config.py
+++ b/rag/src/config.py
@@ -20,6 +20,10 @@ class Settings(BaseSettings):
     top_k: int = 5
     rerank_k: int = 10
 
+    # Embeddings
+    embedding_model: str = "BAAI/bge-m3"
+    embedding_normalize: bool = True
+
     # LLM
     llm_provider: str = "stub"
     llm_model_path: str = ""

--- a/rag/src/infrastructure/ingestion/chunk.py
+++ b/rag/src/infrastructure/ingestion/chunk.py
@@ -2,10 +2,7 @@ from typing import List
 
 
 def chunk_text(text: str, max_chars: int = 800) -> List[str]:
-    # 2단계: 파싱/청킹(naive 고정 길이)
-    chunks = []
-    cursor = 0
-    while cursor < len(text):
-        chunks.append(text[cursor : cursor + max_chars])
-        cursor += max_chars
-    return chunks
+    # 2단계: 파싱/청킹(stub) - 현재는 원문 그대로 1개 청크로 사용
+    _ = max_chars
+    stripped = text.strip()
+    return [stripped] if stripped else []

--- a/rag/src/infrastructure/ingestion/embed.py
+++ b/rag/src/infrastructure/ingestion/embed.py
@@ -1,7 +1,29 @@
+import logging
 from typing import List
+
+from langchain_huggingface import HuggingFaceBgeEmbeddings
+
+from config import settings
+
+logger = logging.getLogger(__name__)
+
+_embedder: HuggingFaceBgeEmbeddings | None = None
+
+
+def _get_embedder() -> HuggingFaceBgeEmbeddings:
+    global _embedder
+    if _embedder is None:
+        _embedder = HuggingFaceBgeEmbeddings(
+            model_name=settings.embedding_model,
+            encode_kwargs={"normalize_embeddings": settings.embedding_normalize},
+        )
+        logger.info("Embedding model loaded: %s", settings.embedding_model)
+    return _embedder
 
 
 def embed_text(texts: List[str]) -> List[List[float]]:
-    # 3단계: 임베딩(stub)
-    # Stub embedder: replace with real embedding model.
-    return [[0.0] * 4 for _ in texts]
+    # 3단계: 임베딩(BGE)
+    if not texts:
+        return []
+    embedder = _get_embedder()
+    return embedder.embed_documents(texts)

--- a/rag/src/interface/api/routes.py
+++ b/rag/src/interface/api/routes.py
@@ -70,7 +70,10 @@ def generate_risk_report(
 
 
 @router.post("/upload/pdf")
-async def upload_pdf(file: UploadFile = File(...)) -> dict:
+async def upload_pdf(
+    file: UploadFile = File(...),
+    service: IngestionService = Depends(get_ingestion_service),
+) -> dict:
     # 업로드된 PDF 파일을 data 디렉터리에 저장
     if not file.filename:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing filename.")
@@ -84,6 +87,7 @@ async def upload_pdf(file: UploadFile = File(...)) -> dict:
     target_path = data_dir / safe_name
     content = await file.read()
     target_path.write_bytes(content)
+    service.ingest_pdf_file(target_path, data_dir)
     return {"status": "ok", "path": str(target_path)}
 
 


### PR DESCRIPTION
[RAG 임베딩 과정 파이프라인 구축]
- PyMuPDF로 업로드 PDF를 텍스트 추출 → stub chunking → BGE 임베딩 → Qdrant 업서트까지 연결했고, 리트리벌 결과를 리스크 리포트에 포함

[클린 아키텍처를 위한 리팩토링]
- 리스크 리포트 구조를 오케스트레이션/리트리버/프롬프트/파서로 분리

[Scalar & Vector DB 연결 추가]
- MariaDB+Qdrant 근거를 섞어 PI 매트릭스 분석 흐름을 구현했어.

[디버깅을 위한 실행 로그 추가]
  - 단계별 로그/타임아웃/테스트 시드 데이터를 추가해서 병목 추적과 실행 안정성을 높였어.